### PR TITLE
Moving 1.4 update forward.

### DIFF
--- a/GameData/VenStockRevamp/Squad/Data/Engines.cfg
+++ b/GameData/VenStockRevamp/Squad/Data/Engines.cfg
@@ -1187,9 +1187,9 @@ PART
 	!mesh = DELETE
 	MODEL{
         model = VenStockRevamp/Squad/Parts/Propulsion/PoodleS2NTR
-		position = 0, 0.7269405, 0
+		position = 0, 1.1947844, 0
 	}
-	@node_stack_bottom = 0.0, -1.2032795, 0.0, 0.0, -1.0, 0.0, 2
+	@node_stack_top = 0.0, 1.1947844, 0.0, 0.0, 1.0, 0.0, 2
 	@MODULE[ModuleGimbal]{
 		%gimbalResponseSpeed = 6
 	}	


### PR DESCRIPTION
Scooting new Poodle model forward, so it won't interfere with decouplers in craft upgrading from stock.