### PR TITLE
Mark current release as compatible with KSP 1.10

### DIFF
--- a/GameData/VenStockRevamp/VenStockRevamp.version
+++ b/GameData/VenStockRevamp/VenStockRevamp.version
@@ -1,32 +1,28 @@
 {
   "NAME": "VenStockRevamp",
   "URL": "https://raw.githubusercontent.com/Kerbas-ad-astra/Stock-Revamp/master/GameData/VenStockRevamp/VenStockRevamp.version",
-  "GITHUB":
-    {
-        "USERNAME":"Kerbas-ad-astra",
-        "REPOSITORY":"Stock-Revamp",
-        "ALLOW_PRE_RELEASE":false,
-    },
+  "GITHUB": {
+    "USERNAME": "Kerbas-ad-astra",
+    "REPOSITORY": "Stock-Revamp",
+    "ALLOW_PRE_RELEASE": false,
+  },
   "VERSION": {
     "MAJOR": 1,
     "MINOR": 15,
-	"PATCH": 1
+    "PATCH": 1
   },
   "KSP_VERSION": {
     "MAJOR": 1,
     "MINOR": 9,
     "PATCH": 1
   },
-  "KSP_VERSION_MIN":
-	{
-		"MAJOR":1,
-		"MINOR":9,
-		"PATCH":0
-	},
-	"KSP_VERSION_MAX":
-	{
-		"MAJOR":1,
-		"MINOR":9,
-		"PATCH":1
-	}
+  "KSP_VERSION_MIN": {
+    "MAJOR": 1,
+    "MINOR": 9,
+    "PATCH": 0
+  },
+  "KSP_VERSION_MAX": {
+    "MAJOR": 1,
+    "MINOR": 10
+  }
 }


### PR DESCRIPTION
Hi @Kerbas-ad-astra,

@NathanKell says you're OK with marking this mod as compatible with KSP 1.10. This pull request updates the remote version file to reflect that; if these changes are merged, then the CKAN bot will automatically update the metadata to reflect them (and KSP-AVC and MiniAVC will likewise consider KSP 1.10 to be OK for this mod).

Closes KSP-CKAN/NetKAN#8648.