### PR TITLE
Mark latest version compatible starting from KSP v1.10

### DIFF
--- a/GameData/VenStockRevamp/VenStockRevamp.version
+++ b/GameData/VenStockRevamp/VenStockRevamp.version
@@ -20,7 +20,7 @@
   "KSP_VERSION_MIN":
 	{
 		"MAJOR":1,
-		"MINOR":12,
+		"MINOR":10,
 		"PATCH":0
 	},
 	"KSP_VERSION_MAX":


### PR DESCRIPTION
The notes on the last release already mention 1.10 support and it's known to work properly on that version.

This is needed to support AJE on both KSP v1.10 and v1.12. https://github.com/KSP-RO/AJE/pull/31