### PR TITLE
Fix cfg syntax errors

### DIFF
--- a/GameData/VenStockRevamp/Patches/RealChute-Patches.cfg
+++ b/GameData/VenStockRevamp/Patches/RealChute-Patches.cfg
@@ -5,8 +5,8 @@
 	maximum_drag = 0.32
 	@cost = 350
 	@mass = 0.04
-	!sound_parachute_open
-	!sound_parachute_single
+	!sound_parachute_open = DELETE
+	!sound_parachute_single = DELETE
 
 	!MODULE[ModuleParachute]{}
 
@@ -94,8 +94,8 @@
 	maximum_drag = 0.32
 	@cost = 250
 	@mass = 0.06
-	!sound_parachute_open
-	!sound_parachute_single
+	!sound_parachute_open = DELETE
+	!sound_parachute_single = DELETE
 	
 	@MODEL {
         @model = VenStockRevamp/Squad/Parts/DockingPorts/ParaDockingPortDual


### PR DESCRIPTION
Hi @Kerbas-ad-astra,

I've been working on some cfg parser code for KSP-CKAN/CKAN#3525, and I tested it on this mod and found a few minor syntax errors (deletions missing `=`).

This pull request fixes them.

Cheers!